### PR TITLE
Fixes media-messages with caption #52

### DIFF
--- a/bot/bot.py
+++ b/bot/bot.py
@@ -644,7 +644,7 @@ class SkipDuplicateMessageHandler(MessageHandler):
 
     def check(self, event, dispatcher):
         if super(SkipDuplicateMessageHandler, self).check(event=event, dispatcher=dispatcher):
-            if self.cache.get(event.data["msgId"]) == event.data["text"]:
+            if self.cache.get(event.data["msgId"]) == event.data.get("text", False):
                 raise StopDispatching
 
 

--- a/bot/filter.py
+++ b/bot/filter.py
@@ -75,7 +75,9 @@ class InvertFilter(FilterBase):
 
 class MessageFilter(FilterBase):
     def filter(self, event):
-        return "text" in event.data and isinstance(event.data["text"], six.string_types)
+        return ("text" in event.data and isinstance(event.data["text"], six.string_types)) or (
+            "parts" in event.data and any(p.get("payload", {}).get("caption") for p in event.data["parts"])
+        )
 
 
 class CommandFilter(MessageFilter):


### PR DESCRIPTION
- Сделал небольшое костыльное исправление для `SkipDuplicateMessageHandler` - теперь там не выбрасывается KeyError при отсуствии в `event.data` поля `text`. Процесс dispatching-а вроде не ломает.
- И устарнил основную проблему с фильтрами медиа при наличии подписей, описанную в https://github.com/mail-ru-im/bot-python/issues/52 - теперь сообщения с подписями ловятся в фильтром `MessageFilter`.

Если считаете, что новое поведение стоит унести в новый класс - уточните название, внесу необходимые изменения.